### PR TITLE
Descriptor instead of triad (renaming)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,29 +2,29 @@
 
 //! Module level docs
 
-/// Struct for a triad
-struct Triad {
+/// Struct for a descriptor
+struct Descriptor {
     f: u8,
     x: u8,
     y: u8,
 }
 
-/// Parses a triad from a BUFR message.
+/// Parses a descriptor from a BUFR message.
 ///
-/// A Triad has 3 fields:
+/// A Descriptor has 3 fields:
 /// - f (2 bits):
 /// - x (2 bits):
 /// - y (8 bits):
-fn parse_triad(buf: [u8; 2]) -> Triad {
+fn parse_descriptor(buf: [u8; 2]) -> Descriptor {
     let f = (buf[0] & 0b11000000) >> 6;
     let x = buf[0] & 0b00111111;
     let y = buf[1];
 
-    Triad { f, x, y }
+    Descriptor { f, x, y }
 }
 
-impl Triad {
-    fn encode_triad(&self) -> [u8; 2] {
+impl Descriptor {
+    fn encode_descriptor(&self) -> [u8; 2] {
         let mut buf = [0u8; 2];
         buf[0] = (self.f << 6) + self.x;
         buf[1] = self.y;
@@ -34,43 +34,43 @@ impl Triad {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_triad;
+    use super::parse_descriptor;
 
     #[test]
-    fn encode_triad_1() {
+    fn encode_descriptor_1() {
         let test_data = [0, 0];
-        let triad = parse_triad(test_data);
-        let result = triad.encode_triad();
+        let descriptor = parse_descriptor(test_data);
+        let result = descriptor.encode_descriptor();
 
         assert_eq!(test_data, result);
     }
     #[test]
-    fn parse_triad_1() {
+    fn parse_descriptor_1() {
         let test_data = [0, 0];
-        let triad = parse_triad(test_data);
+        let descriptor = parse_descriptor(test_data);
 
-        assert_eq!(triad.f, 0);
-        assert_eq!(triad.x, 0);
-        assert_eq!(triad.y, 0);
+        assert_eq!(descriptor.f, 0);
+        assert_eq!(descriptor.x, 0);
+        assert_eq!(descriptor.y, 0);
     }
 
     #[test]
-    fn parse_triad_2() {
+    fn parse_descriptor_2() {
         let test_data = [0, 1];
-        let triad = parse_triad(test_data);
+        let descriptor = parse_descriptor(test_data);
 
-        assert_eq!(triad.f, 0);
-        assert_eq!(triad.x, 0);
-        assert_eq!(triad.y, 1);
+        assert_eq!(descriptor.f, 0);
+        assert_eq!(descriptor.x, 0);
+        assert_eq!(descriptor.y, 1);
     }
 
     #[test]
-    fn parse_triad_3() {
+    fn parse_descriptor_3() {
         let test_data = [0b10101010, 1];
-        let triad = parse_triad(test_data);
+        let descriptor = parse_descriptor(test_data);
 
-        assert_eq!(triad.f, 2);
-        assert_eq!(triad.x, 42);
-        assert_eq!(triad.y, 1);
+        assert_eq!(descriptor.f, 2);
+        assert_eq!(descriptor.x, 42);
+        assert_eq!(descriptor.y, 1);
     }
 }


### PR DESCRIPTION
To be consistent with the BUFR documentation, let's use descriptor
(F,X,Y) instead of triad.